### PR TITLE
Add DEBUG-only file output for API and auth data

### DIFF
--- a/HevyHeartConsole/Program.cs
+++ b/HevyHeartConsole/Program.cs
@@ -463,11 +463,13 @@ class Program
         }
 
         // Save synchronized data for debugging
+#if DEBUG
         var fileName = $"synchronized_biometrics_{hevyWorkout.GetWorkoutResponseV1.Id}_{DateTime.Now:yyyyMMdd_HHmmss}.json";
         var json = JsonSerializer.Serialize(biometrics, new JsonSerializerOptions { WriteIndented = true });
         await File.WriteAllTextAsync(fileName, json);
-        Console.WriteLine($"Synchronized data saved to: {fileName}");
 
+        Console.WriteLine($"Synchronized data saved to: {fileName}");
+#endif
         // Ask for confirmation before updating Hevy
         Console.WriteLine();
         Console.Write("Do you want to update the Hevy workout with this heart rate data? (y/N): ");

--- a/HevyHeartConsole/Services/HevyService.cs
+++ b/HevyHeartConsole/Services/HevyService.cs
@@ -137,6 +137,7 @@ public class HevyService
             _userId = accountData.Id;
 
             // Save authentication data to file for reference
+
             var authDataFileName = $"hevy_auth_{DateTime.Now:yyyyMMdd_HHmmss}.json";
             var authData = new
             {
@@ -146,9 +147,10 @@ public class HevyService
                 Username = accountData.Username,
                 AuthenticatedAt = DateTime.UtcNow
             };
+#if DEBUG
             await File.WriteAllTextAsync(authDataFileName, 
                 JsonSerializer.Serialize(authData, new JsonSerializerOptions { WriteIndented = true }));
-
+#endif
             Console.WriteLine($"✅ Successfully authenticated as {accountData.Username} (User ID: {_userId})");
             Console.WriteLine($"   Auth data saved to: {authDataFileName}");
             
@@ -180,9 +182,10 @@ public class HevyService
         response.EnsureSuccessStatusCode();
         var content = await response.Content.ReadAsStringAsync();
 
+#if DEBUG
         var fileName = $"hevy_workouts_list_{DateTime.Now:yyyyMMdd_HHmmss}.json";
         await File.WriteAllTextAsync(fileName, content);
-
+#endif
 
         var workoutsResponse = JsonSerializer.Deserialize<HevyWorkoutsResponse>(content);
         
@@ -200,10 +203,10 @@ public class HevyService
         response.EnsureSuccessStatusCode();
 
         var content = await response.Content.ReadAsStringAsync();
-
+#if DEBUG
         var fileName = $"hevy_workout_{workoutId}_{DateTime.Now:yyyyMMdd_HHmmss}.json";
         await File.WriteAllTextAsync(fileName, content);
-
+#endif
         return JsonSerializer.Deserialize<HevyWorkout>(content);
     }
 
@@ -279,9 +282,10 @@ public class HevyService
         response.EnsureSuccessStatusCode();
         
         var content = await response.Content.ReadAsStringAsync();
+#if DEBUG
         var fileName = $"hevy_workout_v2Hybrid_{workoutId}_{DateTime.Now:yyyyMMdd_HHmmss}.json";
         await File.WriteAllTextAsync(fileName, content);
-        
+#endif
         return JsonSerializer.Deserialize<HevyHeartModels.Hevy.V2.GetWorkoutResponse>(content);
     }
 
@@ -320,9 +324,10 @@ public class HevyService
         response.EnsureSuccessStatusCode();
 
         var content = await response.Content.ReadAsStringAsync();
+#if DEBUG
         var fileName = $"hevy_workout_v2Hybrid_{workoutId}_{DateTime.Now:yyyyMMdd_HHmmss}.json";
         await File.WriteAllTextAsync(fileName, content);
-
+#endif
         return JsonSerializer.Deserialize<HevyHeartModels.Hevy.V2.GetWorkoutResponse>(content);
     }
 

--- a/HevyHeartConsole/Services/StravaService.cs
+++ b/HevyHeartConsole/Services/StravaService.cs
@@ -173,6 +173,7 @@ public class StravaService
     /// </remarks>
     public async Task SaveActivityDataAsync(long activityId, StravaDetailedActivity activity, StravaHeartRateStream? heartRateStream)
     {
+#if DEBUG
         var data = new
         {
             Activity = activity,
@@ -184,5 +185,6 @@ public class StravaService
         var fileName = $"strava_activity_{activityId}_{DateTime.Now:yyyyMMdd_HHmmss}.json";
         await File.WriteAllTextAsync(fileName, json);
         Console.WriteLine($"Strava data saved to: {fileName}");
+#endif
     }
 }


### PR DESCRIPTION
Wrap file-saving and related console output in #if DEBUG blocks to restrict debug data exports to Debug builds only. Affects biometrics, Hevy authentication, workout data, and Strava activity exports. Prevents unnecessary file creation in Release.