### PR TITLE
Change output to Library; stop copying appsettings.json

### DIFF
--- a/HevyHeartConsole/HevyHeartConsole.csproj
+++ b/HevyHeartConsole/HevyHeartConsole.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <OutputType>Exe</OutputType>
+        <OutputType>Library</OutputType>
         <TargetFramework>net9.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
@@ -31,7 +31,7 @@
 
     <ItemGroup>
       <None Update="appsettings.json">
-        <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+        <CopyToOutputDirectory>Never</CopyToOutputDirectory>
       </None>
     </ItemGroup>
 


### PR DESCRIPTION
Changed project output type from Exe to Library in HevyHeartConsole.csproj. Updated appsettings.json settings to prevent it from being copied to the output directory during build.